### PR TITLE
Increase acceptable deploy lag to a month

### DIFF
--- a/lib/message_generator.rb
+++ b/lib/message_generator.rb
@@ -28,7 +28,7 @@ class MessageGenerator
 
     merge_date_of_oldest_pull_request = unpdeployed_pull_requests.first[:commit][:committer][:date]
 
-    return unless merge_date_of_oldest_pull_request < (Time.now - 14.days)
+    return unless merge_date_of_oldest_pull_request < (Time.now - 31.days)
 
     seconds_ago = ((Time.now - merge_date_of_oldest_pull_request).abs).round
     days_ago = seconds_ago / 1.day


### PR DESCRIPTION
We currently have a bunch of apps with a big deploy lag. To slowly work our way through them only display > 31 days now.

This should be lowered soon.