### PR TITLE
Rename CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on: [push, pull_request]
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It needs to be named `test` to match the requires branch protection rules: https://github.com/alphagov/govuk-saas-config/blob/aebb18d9cd32664c94d2bb63d832804ffec222b8/github/lib/configure_repo.rb#L104

Similar to https://github.com/alphagov/smart-answers/pull/4692