### PR TITLE
Upgrade activesupport version from 5.2.1.1 to 5.2.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1.1)
+    activesupport (5.2.8.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -9,7 +9,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.10)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -106,7 +106,7 @@ GEM
       faraday (> 0.8, < 2.0)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    tzinfo (1.2.5)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -136,4 +136,4 @@ RUBY VERSION
    ruby 2.7.6
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Trello card: https://trello.com/c/YgZ85MX2/2938-urgent-updates-to-our-apps-to-fix-an-active-record-rce-vulnerability